### PR TITLE
Transform validation logic into async code

### DIFF
--- a/src/deps.deno.ts
+++ b/src/deps.deno.ts
@@ -1,11 +1,55 @@
-import { hmac } from "https://deno.land/x/hmac@v2.0.1/mod.ts";
+import { createHash, createHmac } from "https://deno.land/std@0.160.0/node/crypto.ts"
 
-export { sha256 } from "https://denopkg.com/chiefbiiko/sha256@v2.0.0/mod.ts";
-
-export function hmacSha256(key: string | Uint8Array, msg: string) {
-    return hmac("sha256", key, msg);
+export function sha256 (payload: string) {
+    return createHash("sha256").update(payload).digest() as Uint8Array
 }
 
-export function hmacSha256Hex(key: string | Uint8Array, msg: string) {
-    return hmac("sha256", key, msg, "utf8", "hex");
+export function hmacSha256 (key: string | Uint8Array, msg: string) {
+    return createHmac("sha256", key).update(msg).digest() as Uint8Array
 }
+
+export function hmacSha256Hex (key: string | Uint8Array, msg: string) {
+    return createHmac("sha256", key).update(msg).digest("hex") as string
+}
+
+export function sha256Async (payload: string) {
+    return new Promise<Uint8Array>((resolve, reject) => {
+        const hash = createHash("sha256")
+        hash.on("readable", () => {
+            const data = hash.read()
+            if (data) resolve(data)
+        })
+        hash.on("error", (error) => reject(error))
+        hash.write(payload)
+        hash.end()
+    })
+}
+
+function hmacSha256AsyncBase (key: string | Uint8Array, msg: string, digest: null): Promise<Uint8Array>
+function hmacSha256AsyncBase (key: string | Uint8Array, msg: string, digest: 'utf-8' | 'hex' | 'base64'): Promise<string>
+function hmacSha256AsyncBase (key: string | Uint8Array, msg: string, digest: 'utf-8' | 'hex' | 'base64' | null): Promise<Uint8Array | string> {
+    return new Promise<Uint8Array>((resolve, reject) => {
+        const hash = createHmac("sha256", key)
+        hash.on("readable", () => {
+            const data = hash.read()
+            if (data) {
+                if (digest) {
+                    return resolve(data.toString(digest))
+                }
+                return resolve(data)
+            }
+        })
+        hash.on("error", (error) => reject(error))
+        hash.write(msg)
+        hash.end()
+    })
+}
+
+export function hmacSha256Async (key: string | Uint8Array, msg: string) {
+    return hmacSha256AsyncBase(key, msg, null)
+}
+
+export function hmacSha256AsyncHex (key: string | Uint8Array, msg: string) {
+    return hmacSha256AsyncBase(key, msg, 'hex')
+}
+

--- a/src/deps.node.ts
+++ b/src/deps.node.ts
@@ -1,13 +1,54 @@
-import { createHash, createHmac } from "crypto";
+import { createHash, createHmac } from "crypto"
 
-export function sha256(payload: string) {
-    return createHash("sha256").update(payload).digest();
+export function sha256 (payload: string) {
+    return createHash("sha256").update(payload).digest()
 }
 
-export function hmacSha256(key: string | Uint8Array, msg: string) {
-    return createHmac("sha256", key).update(msg).digest();
+export function hmacSha256 (key: string | Uint8Array, msg: string) {
+    return createHmac("sha256", key).update(msg).digest()
 }
 
-export function hmacSha256Hex(key: string | Uint8Array, msg: string) {
-    return createHmac("sha256", key).update(msg).digest("hex");
+export function hmacSha256Hex (key: string | Uint8Array, msg: string) {
+    return createHmac("sha256", key).update(msg).digest("hex")
+}
+
+export function sha256Async (payload: string) {
+    return new Promise<Buffer>((resolve, reject) => {
+        const hash = createHash("sha256")
+        hash.on("readable", () => {
+            const data = hash.read()
+            if (data) resolve(data)
+        })
+        hash.on("error", (error: Error) => reject(error))
+        hash.write(payload)
+        hash.end()
+    })
+}
+
+function hmacSha256AsyncBase (key: string | Uint8Array, msg: string, digest: null): Promise<Buffer>
+function hmacSha256AsyncBase (key: string | Uint8Array, msg: string, digest: 'utf-8' | 'hex' | 'base64'): Promise<string>
+function hmacSha256AsyncBase (key: string | Uint8Array, msg: string, digest: 'utf-8' | 'hex' | 'base64' | null): Promise<string | Buffer> {
+    return new Promise((resolve, reject) => {
+        const hash = createHmac("sha256", key)
+        hash.on("readable", () => {
+            const data = hash.read()
+            if (data) {
+                if (digest) {
+                    return resolve(data.toString(digest))
+                }
+                return resolve(data)
+            }
+        })
+        hash.on("error", (error: Error) => reject(error))
+        hash.write(msg)
+        hash.end()
+    })
+}
+
+export function hmacSha256Async (key: string | Uint8Array, msg: string) {
+    return hmacSha256AsyncBase(key, msg, null)
+}
+
+export function hmacSha256AsyncHex (key: string | Uint8Array, msg: string) {
+    return hmacSha256AsyncBase(key, msg, 'hex')
 }


### PR DESCRIPTION
This fixes #1 

I duplicated the functions into their `async` versions to avoid breaking changes, however, if a breaking change is required I can update it to include only the async signatures.

I also replaced the current functions from chiefbiiko for the nodejs backports from deno std because they implement the hashing in the stream format so I can make it truly async instead of just scheduling it for next tick.