### PR TITLE
Only use important keys from data and allow numbers, strings and undefined values

### DIFF
--- a/src/mod.ts
+++ b/src/mod.ts
@@ -1,27 +1,37 @@
 import { hmacSha256, hmacSha256Hex, sha256 } from "./deps.deno.ts";
 
-export function checkSignature(
-    token: string,
-    { hash, ...data }: Record<string, string>,
-) {
-    const secretKey = sha256(token);
-    return compareHmac(secretKey, hash, data);
+export interface TelegramPayload {
+  id: string | number;
+  hash: string;
+  auth_date: string | number;
+  username?: string;
+  last_name?: string;
+  photo_url?: string;
+  first_name?: string;
+}
+// This type allows for extra data to be passed in the payload.
+export type TelegramPayloadExtended = TelegramPayload & Record<string, string | number | undefined>;
+
+const payloadKeys = ["id", "hash", "auth_date", "username", "last_name", "photo_url", "first_name"];
+
+export function checkSignature(token: string, { hash, ...data }: TelegramPayloadExtended) {
+  const secretKey = sha256(token);
+  return compareHmac(secretKey, hash, data);
 }
 
 export function validateWebAppData(token: string, initData: URLSearchParams) {
-    const secretKey = hmacSha256("WebAppData", token);
-    const { hash, ...data } = Object.fromEntries(initData.entries());
-    return compareHmac(secretKey, hash, data);
+  const secretKey = hmacSha256("WebAppData", token);
+  const { hash, ...data } = Object.fromEntries(initData.entries());
+  return compareHmac(secretKey, hash, data);
 }
 
-function compareHmac(
-    secretKey: string | Uint8Array,
-    hash: string,
-    data: Record<string, string>,
-) {
-    const dataCheckString = Object.keys(data)
-        .sort()
-        .map((k) => `${k}=${data[k]}`)
-        .join("\n");
-    return hash === hmacSha256Hex(secretKey, dataCheckString);
+function compareHmac(secretKey: string | Uint8Array, hash: string, data: Omit<TelegramPayloadExtended, "hash">) {
+  const dataCheckString = Object.keys(data)
+    // only the keys we care about and not undefined
+    .filter((k) => payloadKeys.includes(k) && typeof data[k] !== "undefined")
+    .sort()
+    .map((k) => `${k}=${data[k]}`)
+    .join("\n");
+
+  return hash === hmacSha256Hex(secretKey, dataCheckString);
 }

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -6,7 +6,7 @@ const payloadKeys = ["id", "hash", "auth_date", "username", "last_name", "photo_
 
 export function checkSignature(token: string, { hash, ...data }: Payload) {
   const secretKey = sha256(token);
-  if (!hash) throw new Error("No hash provided");
+  if (!hash) return false;
   return compareHmac(secretKey, `${hash}`, data);
 }
 


### PR DESCRIPTION
![image](https://github.com/grammyjs/validator/assets/12930717/67cf4dfa-3393-400b-922c-436291449b60)