### PR TITLE
feat: implement validation check for maximum WebApp data age

### DIFF
--- a/src/mod.ts
+++ b/src/mod.ts
@@ -12,9 +12,9 @@ export function checkSignature(token: string, { hash, ...data }: Payload) {
 
 /**
  * @param maxAge Maximum time in seconds passed since `auth_date` in order to
- * consider the `initData` valid. Use `0` to disable.
+ * consider the `initData` valid.
  */
-export function validateWebAppData(token: string, initData: URLSearchParams, maxAge: number) {
+export function validateWebAppData(token: string, initData: URLSearchParams, maxAge: number | false) {
   const secretKey = hmacSha256("WebAppData", token);
   const { hash, ...data } = Object.fromEntries(initData.entries());
 

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -10,9 +10,21 @@ export function checkSignature(token: string, { hash, ...data }: Payload) {
   return compareHmac(secretKey, `${hash}`, data);
 }
 
-export function validateWebAppData(token: string, initData: URLSearchParams) {
+/**
+ * @param maxAge Maximum time in seconds passed since `auth_date` in order to
+ * consider the `initData` valid. Use `0` to disable.
+ */
+export function validateWebAppData(token: string, initData: URLSearchParams, maxAge: number) {
   const secretKey = hmacSha256("WebAppData", token);
   const { hash, ...data } = Object.fromEntries(initData.entries());
+
+  if (maxAge) {
+    const authDate = Number(data.auth_date);
+    if (isNaN(authDate)) return false;
+    const age = (Date.now() / 1000) - authDate;
+    if (age > maxAge) return false;
+  }
+
   return compareHmac(secretKey, hash, data);
 }
 


### PR DESCRIPTION
I added  a `maxAge` parameter to the `validateWebAppData()` function.

I left it required so the developer has to disable the age validation check explicitly. In my opinion this sounds better from a security pov, but beware that **this implies a breaking change**. If this is a problem I can make the parameter optional.