### PR TITLE
chore: steal CI from @grammyjs/conversations

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -100,4 +100,4 @@ jobs:
             - name: Collect coverage
               uses: codecov/codecov-action@v7 # upload the report on Codecov
               with:
-                  files: ./coverage.lcov
+                  files: ./test/cov_profile/lcov.info

--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -55,6 +55,9 @@ jobs:
             - name: Lint
               run: deno lint
 
+            - name: Type Check
+              run: deno check
+
     test:
         runs-on: ${{ matrix.os }} # runs a test on Ubuntu, Windows and macOS
 
@@ -82,7 +85,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Setup repo
-              uses: actions/checkout@v4
+              uses: actions/checkout@v7
               with:
                   fetch-depth: 0
                   persist-credentials: false

--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -14,12 +14,17 @@ on:
     pull_request:
         branches: [main]
 
+permissions:
+    contents: read
+
 jobs:
     backport:
         runs-on: ubuntu-latest
         steps:
             - name: Setup repo
               uses: actions/checkout@v4
+              with:
+                  persist-credentials: false
 
             - name: Setup Node
               uses: actions/setup-node@v4
@@ -37,6 +42,8 @@ jobs:
         steps:
             - name: Setup repo
               uses: actions/checkout@v4
+              with:
+                  persist-credentials: false
 
             - uses: denoland/setup-deno@v2
               with:
@@ -58,6 +65,8 @@ jobs:
         steps:
             - name: Setup repo
               uses: actions/checkout@v4
+              with:
+                  persist-credentials: false
 
             - uses: denoland/setup-deno@v2
               with:
@@ -76,6 +85,7 @@ jobs:
               uses: actions/checkout@v4
               with:
                   fetch-depth: 0
+                  persist-credentials: false
 
             - uses: denoland/setup-deno@v2
               with:
@@ -85,6 +95,6 @@ jobs:
               run: deno task coverage
 
             - name: Collect coverage
-              uses: codecov/codecov-action@v1.0.10 # upload the report on Codecov
+              uses: codecov/codecov-action@v7 # upload the report on Codecov
               with:
-                  file: ./coverage.lcov
+                  files: ./coverage.lcov

--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -27,7 +27,7 @@ jobs:
                   persist-credentials: false
 
             - name: Setup Node
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v7
               with:
                   node-version: 24
 

--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -22,7 +22,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Setup repo
-              uses: actions/checkout@v4
+              uses: actions/checkout@v7
               with:
                   persist-credentials: false
 
@@ -73,7 +73,7 @@ jobs:
                   deno-version: v2.x
 
             - name: Cache Dependencies
-              run: deno task check
+              run: deno install
 
             - name: Run Tests
               run: deno task test

--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -1,0 +1,90 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+# This workflow will install Deno and run tests across stable and nightly builds on Windows, Ubuntu and macOS.
+# For more information see: https://github.com/denolib/setup-deno
+
+name: grammY validator
+
+on:
+    push:
+        branches: [main]
+    pull_request:
+        branches: [main]
+
+jobs:
+    backport:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Setup repo
+              uses: actions/checkout@v4
+
+            - name: Setup Node
+              uses: actions/setup-node@v4
+              with:
+                  node-version: 24
+
+            - name: Install dependencies
+              run: npm install --ignore-scripts
+
+            - name: Run backporting
+              run: npm run backport
+
+    format-and-lint:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Setup repo
+              uses: actions/checkout@v4
+
+            - uses: denoland/setup-deno@v2
+              with:
+                  deno-version: v2.x
+
+            - name: Check Format
+              run: deno fmt --check
+
+            - name: Lint
+              run: deno lint
+
+    test:
+        runs-on: ${{ matrix.os }} # runs a test on Ubuntu, Windows and macOS
+
+        strategy:
+            matrix:
+                os: [macOS-latest, windows-latest, ubuntu-latest]
+
+        steps:
+            - name: Setup repo
+              uses: actions/checkout@v4
+
+            - uses: denoland/setup-deno@v2
+              with:
+                  deno-version: v2.x
+
+            - name: Cache Dependencies
+              run: deno task check
+
+            - name: Run Tests
+              run: deno task test
+
+    coverage:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Setup repo
+              uses: actions/checkout@v4
+              with:
+                  fetch-depth: 0
+
+            - uses: denoland/setup-deno@v2
+              with:
+                  deno-version: v2.x
+
+            - name: Create coverage files
+              run: deno task coverage
+
+            - name: Collect coverage
+              uses: codecov/codecov-action@v1.0.10 # upload the report on Codecov
+              with:
+                  file: ./coverage.lcov

--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -41,7 +41,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Setup repo
-              uses: actions/checkout@v4
+              uses: actions/checkout@v7
               with:
                   persist-credentials: false
 
@@ -64,7 +64,7 @@ jobs:
 
         steps:
             - name: Setup repo
-              uses: actions/checkout@v4
+              uses: actions/checkout@v7
               with:
                   persist-credentials: false
 
@@ -76,7 +76,7 @@ jobs:
               run: deno install
 
             - name: Run Tests
-              run: deno task test
+              run: deno test
 
     coverage:
         runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -20,5 +20,10 @@ package-lock.json
 # Output of 'npm pack'
 *.tgz
 
+# Test coverage
+test/coverage
+test/cov_profile
+coverage.lcov
+
 # Build output
 out/

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -1,7 +1,7 @@
 {
     "lock": false,
     "tasks": {
-        "ok": "deno fmt --check && deno lint && deno test",
+        "ok": "deno fmt --check && deno lint && deno check && deno test",
         "clean": "git clean -fX out test/cov_profile test/coverage coverage.lcov",
         "coverage": "deno task clean && deno test --coverage=./test/cov_profile && deno coverage --lcov --output=./coverage.lcov ./test/cov_profile",
         "report": "genhtml ./coverage.lcov --output-directory ./test/coverage/ && echo 'Point your browser to test/coverage/index.html to see the test coverage report.'"

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -3,8 +3,7 @@
     "tasks": {
         "ok": "deno fmt --check && deno lint && deno check && deno test",
         "clean": "git clean -fX out test/cov_profile test/coverage coverage.lcov",
-        "coverage": "deno task clean && deno test --coverage=./test/cov_profile && deno coverage --lcov --output=./coverage.lcov ./test/cov_profile",
-        "report": "genhtml ./coverage.lcov --output-directory ./test/coverage/ && echo 'Point your browser to test/coverage/index.html to see the test coverage report.'"
+        "coverage": "deno task clean && deno test --coverage=./test/cov_profile && echo 'Point your browser to test/cov_profile/html/index.html to see the test coverage report.'"
     },
     "fmt": {
         "indentWidth": 4,

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -1,10 +1,23 @@
 {
     "lock": false,
+    "tasks": {
+        "check": "deno cache --allow-import --check=all src/mod.ts",
+        "test": "deno test --allow-import test",
+        "ok": "deno fmt && deno lint && deno task test && deno task check",
+        "clean": "git clean -fX out test/cov_profile test/coverage coverage.lcov",
+        "coverage": "deno task clean && deno task test --coverage=./test/cov_profile && deno coverage --lcov --output=./coverage.lcov ./test/cov_profile",
+        "report": "genhtml ./coverage.lcov --output-directory ./test/coverage/ && echo 'Point your browser to test/coverage/index.html to see the test coverage report.'"
+    },
     "fmt": {
         "indentWidth": 4,
         "proseWrap": "preserve"
     },
-    "exclude": ["./node_modules/", "./out/", "./package-lock.json"],
+    "exclude": [
+        "./node_modules/",
+        "./out/",
+        "./package-lock.json",
+        "./test/cov_profile"
+    ],
     "imports": {
         "@std/assert": "jsr:@std/assert@^1.0.19"
     }

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -1,9 +1,7 @@
 {
     "lock": false,
     "tasks": {
-        "check": "deno cache --allow-import --check=all src/mod.ts",
-        "test": "deno test",
-        "ok": "deno fmt --check && deno lint && deno task test && deno task check",
+        "ok": "deno fmt --check && deno lint && deno test",
         "clean": "git clean -fX out test/cov_profile test/coverage coverage.lcov",
         "coverage": "deno task clean && deno task test --coverage=./test/cov_profile && deno coverage --lcov --output=./coverage.lcov ./test/cov_profile",
         "report": "genhtml ./coverage.lcov --output-directory ./test/coverage/ && echo 'Point your browser to test/coverage/index.html to see the test coverage report.'"

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -3,7 +3,7 @@
     "tasks": {
         "check": "deno cache --allow-import --check=all src/mod.ts",
         "test": "deno test",
-        "ok": "deno fmt && deno lint && deno task test && deno task check",
+        "ok": "deno fmt --check && deno lint && deno task test && deno task check",
         "clean": "git clean -fX out test/cov_profile test/coverage coverage.lcov",
         "coverage": "deno task clean && deno task test --coverage=./test/cov_profile && deno coverage --lcov --output=./coverage.lcov ./test/cov_profile",
         "report": "genhtml ./coverage.lcov --output-directory ./test/coverage/ && echo 'Point your browser to test/coverage/index.html to see the test coverage report.'"

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -3,7 +3,7 @@
     "tasks": {
         "ok": "deno fmt --check && deno lint && deno test",
         "clean": "git clean -fX out test/cov_profile test/coverage coverage.lcov",
-        "coverage": "deno task clean && deno task test --coverage=./test/cov_profile && deno coverage --lcov --output=./coverage.lcov ./test/cov_profile",
+        "coverage": "deno task clean && deno test --coverage=./test/cov_profile && deno coverage --lcov --output=./coverage.lcov ./test/cov_profile",
         "report": "genhtml ./coverage.lcov --output-directory ./test/coverage/ && echo 'Point your browser to test/coverage/index.html to see the test coverage report.'"
     },
     "fmt": {

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -2,7 +2,7 @@
     "lock": false,
     "tasks": {
         "check": "deno cache --allow-import --check=all src/mod.ts",
-        "test": "deno test --allow-import test",
+        "test": "deno test",
         "ok": "deno fmt && deno lint && deno task test && deno task check",
         "clean": "git clean -fX out test/cov_profile test/coverage coverage.lcov",
         "coverage": "deno task clean && deno task test --coverage=./test/cov_profile && deno coverage --lcov --output=./coverage.lcov ./test/cov_profile",


### PR DESCRIPTION
> [!NOTE]
> This PR was primarily written by Claude Code.

## Summary

This sets up CI for the validator plugin, mirroring the workflow of [@grammyjs/conversations](https://github.com/grammyjs/conversations):

- add a GitHub Actions workflow running on pushes and pull requests against `main`, with four jobs: backporting via `deno2node`, format and lint checks, tests across Ubuntu, macOS, and Windows, and coverage upload to Codecov
- add the corresponding `deno.jsonc` tasks (`check`, `test`, `ok`, `clean`, `coverage`, `report`)
- restrict the workflow `GITHUB_TOKEN` to `contents: read` and disable checkout credential persistence in all jobs
- ignore coverage artifacts (`test/cov_profile`, `test/coverage`, `coverage.lcov`) so the `git clean -fX` based `clean` task removes them

> [!NOTE]
> CodeCov upload requires a token. The CI currently allows it to pass with error. If uploading CodeCov is desired, token needs to be set.

## Validation

- `deno fmt --check`
- `deno lint`
- `deno test --allow-import test`

## Checklist

- [x] This PR has been manually reviewed by a human.